### PR TITLE
Add toggle and shortcut for player control show/hide

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,7 @@
 // set initial state of extension on install
 chrome.runtime.onInstalled.addListener(() => {
     chrome.storage.sync.set({ydrIsEnabled: true});
+    chrome.storage.sync.set({hidePlayer: false});
 })
 
 // tab listeners to check for: switched to youtube tab, loading completes

--- a/background.js
+++ b/background.js
@@ -4,6 +4,17 @@ chrome.runtime.onInstalled.addListener(() => {
     chrome.storage.sync.set({hidePlayer: false});
 })
 
+// event listener for command macro from user
+chrome.commands.onCommand.addListener((command) => {
+    if (command === "hidePlayerCommand") {
+      chrome.storage.sync.get("hidePlayer", (data) => {
+        const newValue = !data.hidePlayer;
+        chrome.storage.sync.set({ hidePlayer: newValue });
+      });
+      logPopup("User toggled macro for hidePlayer, updated state:", newValue);
+    }
+});
+
 // tab listeners to check for: switched to youtube tab, loading completes
 chrome.tabs.onActivated.addListener(async (activeInfo) => {
     const tab = await chrome.tabs.get(activeInfo.tabId);

--- a/content.js
+++ b/content.js
@@ -1,3 +1,19 @@
+// DOM element selectors for thumbnail duration
+const durationElements = [
+    'ytd-thumbnail-overlay-time-status-renderer', //static thumbnail video duration
+    'yt-inline-player-controls', // video duration in hover preview
+    'ytd-thumbnail-overlay-resume-playback-renderer' // thumbnail progress bar
+];
+
+// DOM element selectors for video player controls
+const playerElements = [
+    'ytp-chrome-controls',
+    'ytp-gradient-top',
+    'ytp-gradient-bottom',
+    'ytp-progress-bar',
+    'ytp-progress-bar-container'
+];
+
 let observer = new MutationObserver((mutations) => {
     mutations.forEach(mutation => {
         if (mutation.addedNodes.length || mutation.type === "childList") {
@@ -105,71 +121,47 @@ function isYdrOn() {
 }
 
 function removeDurationLabels() {
-    // remove static thumbnail durations
-    const overlayContainers = document.querySelectorAll('ytd-thumbnail-overlay-time-status-renderer');
-    overlayContainers.forEach(container => {
-      container.style.display = "none"; // hide to be able to restore later
-    });
+    logContent("Hiding thumbnail video durations.");
 
-    // remove hover preview duration
-    const hoverDurationElements = document.querySelectorAll('yt-inline-player-controls');
-    hoverDurationElements.forEach(container => {
-        container.style.display = "none";
-    });
-
-    // remove progress bar in thumbnail
-    const progressDurationElements = document.querySelectorAll('ytd-thumbnail-overlay-resume-playback-renderer');
-    progressDurationElements.forEach(container => {
-        container.style.display = "none"; // hide to be able to restore later
+    durationElements.forEach(element => {
+        const containers = document.querySelectorAll(element);
+        containers.forEach(container => {
+            container.style.display = "none"; // hide elements
+        });
     });
 }
 
 function restoreDurationLabels() {
-    logContent("Restoring YouTube duration previews.");
+    logContent("Restoring thumbnail video durations.");
 
-    // unhide static elements
-    const overlayContainers = document.querySelectorAll('ytd-thumbnail-overlay-time-status-renderer');
-    overlayContainers.forEach(container => {
-        container.style.display = ""; // reset to default style
-    });
-
-    // restore hover preview
-    const hoverDurationElements = document.querySelectorAll('yt-inline-player-controls');
-    hoverDurationElements.forEach(container => {
-        container.style.display = "";
-    });
-
-    // restore progress bar in thumbnail
-    const progressDurationElements = document.querySelectorAll('ytd-thumbnail-overlay-resume-playback-renderer');
-    progressDurationElements.forEach(container => {
-        container.style.display = "";
+    durationElements.forEach(element => {
+        const containers = document.querySelectorAll(element);
+        containers.forEach(container => {
+            container.style.display = ""; // restore default styling for elements
+        });
     });
 }
 
 function hidePlayerControls() {
     try {
-        document.getElementsByClassName('ytp-chrome-top')[0].style.visibility = 'hidden';
-        document.getElementsByClassName('ytp-chrome-controls')[0].style.visibility = 'hidden';
-        document.getElementsByClassName('ytp-gradient-top')[0].style.visibility = 'hidden';
-        document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'hidden';
-        document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'hidden';
-        document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'hidden';    
+        playerElements.forEach(element => {
+            document.getElementsByClassName(element)[0].style.visibility = 'hidden';
+        });
+        logContent("Hiding video player controls.");
     } catch (error) {
-        logContent("Player control elements have not finishing rendering.");
+        logContent("Player control elements have not finishing rendering, will try hiding them again once rendered.");
     }
     
 }
 
 function restorePlayerControls() {
     try {
-        document.getElementsByClassName('ytp-chrome-top')[0].style.visibility = 'visible';
-        document.getElementsByClassName('ytp-chrome-controls')[0].style.visibility = 'visible';
-        document.getElementsByClassName('ytp-gradient-top')[0].style.visibility = 'visible';
-        document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'visible';
-        document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'visible';
-        document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'visible';
+        playerElements.forEach(element => {
+            document.getElementsByClassName(element)[0].style.visibility = 'visible';
+        });
+        logContent("Restoring video player controls.");
     } catch (error) {
-        logContent("Player control elements have not finishing rendering.");
+        logContent("Player control elements have not finishing rendering, will try restoring them again once rendered.");
     }
     
 }

--- a/content.js
+++ b/content.js
@@ -3,14 +3,12 @@ const durationElements = [
     'ytd-thumbnail-overlay-time-status-renderer', //static thumbnail video duration
     'yt-inline-player-controls', // video duration in hover preview
     'ytd-thumbnail-overlay-resume-playback-renderer', // thumbnail progress bar
-    'ytp-time-display' // mini player video duration
 ];
 
 // DOM element selectors for video player controls
 const playerElements = [
-    'ytp-chrome-controls',
-    'ytp-gradient-top',
-    'ytp-gradient-bottom',
+    'ytp-time-wrapper',
+    'ytp-chapter-container',
     'ytp-progress-bar',
     'ytp-progress-bar-container'
 ];

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,15 @@
     "background": {
         "service_worker": "background.js"
     },
+    "commands": {
+        "hidePlayerCommand": {
+            "suggested_key": {
+                "default": "Ctrl+M",
+                "mac": "Command+M"
+            },
+            "description": "Hide/show video player controls"
+        }
+    },
     "content_scripts": [{
         "js": ["log-utils.js", "content.js"],
         "matches": ["*://*.youtube.com/*"],

--- a/popup.html
+++ b/popup.html
@@ -103,7 +103,7 @@
 
             <p>When enabled, the extension will hide video lengths in preview thumbnails.</p>
 
-            <p>Optional: Disable main video player controls for additional spoiler blocking. This can be toggled with CTRL+M.</p>
+            <p>Optional: Disable video time and progress bar in main video player controls for additional spoiler blocking. This can be toggled with CTRL+M.</p>
 
             <label class="switch">
                 <input type="checkbox" id="hidePlayerToggle">

--- a/popup.html
+++ b/popup.html
@@ -103,7 +103,7 @@
 
             <p>When enabled, the extension will hide video lengths in preview thumbnails.</p>
 
-            <p>Optional: Disable main video player controls for additional spoiler blocking. This can be toggled with ctrl+m.</p>
+            <p>Optional: Disable main video player controls for additional spoiler blocking. This can be toggled with CTRL+M.</p>
 
             <label class="switch">
                 <input type="checkbox" id="hidePlayerToggle">

--- a/popup.html
+++ b/popup.html
@@ -101,8 +101,14 @@
 
             <p>Browse Youtube without spoilers for video length.</p>
 
-            <p>When enabled, the extension will hide video player controls along with video lengths in preview thumbnails.</p>
+            <p>When enabled, the extension will hide video lengths in preview thumbnails.</p>
 
+            <p>Optional: Disable main video player controls for additional spoiler blocking. This can be toggled with ctrl+m.</p>
+
+            <label class="switch">
+                <input type="checkbox" id="hidePlayerToggle">
+                <span class="slider"></span>
+            </label>
         </div>
         <script src="log-utils.js"></script>
         <script src="popup.js" defer></script>

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,12 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const toggle = document.getElementById('ydrToggle');
+    const ydrToggle = document.getElementById('ydrToggle');
+    const hidePlayerToggle = document.getElementById('hidePlayerToggle');
 
-    if (!toggle) {
+    if (!ydrToggle) {
+        logPopup("YDR toggle switch element not found.");
+        return;
+    }
+    if (!hidePlayerToggle) {
         logPopup("YDR toggle switch element not found.");
         return;
     }
@@ -9,21 +14,52 @@ document.addEventListener('DOMContentLoaded', function() {
     // check switch state
     chrome.storage.sync.get(['ydrIsEnabled'], function(result) {
         // set switch state
-        toggle.checked = result.ydrIsEnabled ?? true;
+        ydrToggle.checked = result.ydrIsEnabled ?? true;
+    });
+
+    chrome.storage.sync.get(['hidePlayer'], function(result) {
+        hidePlayerToggle.checked = result.hidePlayer ?? false;
     });
     
     // add event listener for switch
-    toggle.addEventListener('change', function() {
-        const newState = toggle.checked;
+    ydrToggle.addEventListener('change', function() {
+        const newYdrState = ydrToggle.checked;
 
         // check storage for value, update if different
         chrome.storage.sync.get(["ydrIsEnabled"], (data) => {
-            if (data.ydrIsEnabled !== newState) {
-                chrome.storage.sync.set({ ydrIsEnabled: newState });
-                logPopup("Switch flipped, updated the ydrIsEnabled state to:", newState);
+            if (data.ydrIsEnabled !== newYdrState) {
+                chrome.storage.sync.set({ ydrIsEnabled: newYdrState });
+                logPopup("YDR switch flipped, updated storage state to:", newYdrState);
+
+                // turn off hidePlayer if overall extension gets turned off
+                if (!newYdrState && hidePlayerToggle.checked) {
+                    chrome.storage.sync.set({ hidePlayer: newYdrState });
+                    logPopup("Also turned off HidePlayer switch.");
+                }
+            }
+        });    
+    });
+
+    hidePlayerToggle.addEventListener('change', function() {
+        const newHidePlayerState = hidePlayerToggle.checked;
+        chrome.storage.sync.get(["hidePlayer"], (data) => {
+            if (data.hidePlayer !== newHidePlayerState) {
+                chrome.storage.sync.set({ hidePlayer: newHidePlayerState });
+                logPopup("HidePlayer switch flipped, updated storage state to:", newHidePlayerState);
             }
         });
     });
+
+});
+
+chrome.storage.onChanged.addListener((changes, namespace) => {
+    if (namespace === 'sync' && changes.hidePlayer) {
+        const hidePlayerToggle = document.getElementById('hidePlayerToggle');
+        if (hidePlayerToggle.checked !== changes.hidePlayer.newValue) {
+            hidePlayerToggle.checked = changes.hidePlayer.newValue;
+            logPopup("Updated HidePlayer switch position due to storage state update.");
+        }
+    }
 });
 
 function logPopup(...args) {


### PR DESCRIPTION
- Add option to toggle on/off video player controls separate from thumbnail durations
- Bind new player control option to CTRL+M to allow users to easily toggle the setting
- Update shown/hidden elements in video player controls to only hide time/progress bar/chapter, while leaving rest of video player controls untouched